### PR TITLE
Add check for nquantiles max value in cpt.np

### DIFF
--- a/R/cpt.R
+++ b/R/cpt.R
@@ -157,6 +157,7 @@ cpt.meanvar=function(data,penalty="MBIC",pen.value=0,method="AMOC",Q=5,test.stat
 cpt.np=function(data, penalty="MBIC", pen.value=0, method="PELT", test.stat="empirical_distribution", class=TRUE, minseglen=1, nquantiles = 10, Q = 5){
     # checkData(data)
     if(minseglen<1){minseglen=1;warning('Minimum segment length cannot be less than 1, automatically changed to be 1.')}
+    if(nquantiles>length(data)){nquantiles=length(data);warning('Maximum nquantiles value cannot be more than length(data), automatically changed to be length(data).')}
 
     if(test.stat=="CUSUM"){
         return(cpt.mean(data=data, penalty=penalty, pen.value=pen.value, method=method, test.stat='CUSUM', class=class, minseglen=minseglen, Q=Q))


### PR DESCRIPTION
We have a problem when `length(data)` is less than `nquantiles`. In this case, `nonparametric.ed.sumstat` returns an `n*(n+1)` array (because of the `if(K>n) K=n` line) instead of `nquantiles*(n+1)` array.

In the `NPPELT` implementation, we have the following lines:

```c
for(isum = 0; isum <*nquantiles; isum++){
    *(sumstatout+isum) = *(sumstat+isum+(*nquantiles*(j))) - *(sumstat+isum+(*nquantiles*(0)));
}
```

Here `sumstat` is the `n*(n+1)` array that was returned by `nonparametric.ed.sumstat`, but we enumarate `isum` values from `0` to `nquantiles` which exceed both dimensions. This problem may lead to incorrect results. An example:

```r
> cpt.np(c(0, 0, 0, 0, 0, 1, 1, 1, 1))@cpts
[1] 3 9
```

As you can see, the result is incorrect.
Now let's try to manually reduce the `nquantiles` value:

```r
> cpt.np(c(0, 0, 0, 0, 0, 1, 1, 1, 1), nquantiles = 9)@cpts
[1] 5 9
```

It fixes the problem; the result is correct now.

In general case, the problem can be fixed by setting `nquantiles=length(data)` when `nquantiles>length(data)`.